### PR TITLE
Ignore minecraft brand channel

### DIFF
--- a/src/main/java/com/gigazelensky/antispoof/AntiSpoofPlugin.java
+++ b/src/main/java/com/gigazelensky/antispoof/AntiSpoofPlugin.java
@@ -330,7 +330,9 @@ public class AntiSpoofPlugin extends JavaPlugin {
         PlayerData data = playerDataMap.get(uuid);
         if (data == null) return false;
         
-        boolean hasChannels = !data.getChannels().isEmpty();
+        // Exclude ignored channels (like minecraft:brand) from detection logic
+        Set<String> filteredChannels = detectionManager.getFilteredChannels(data.getChannels());
+        boolean hasChannels = !filteredChannels.isEmpty();
         boolean claimsVanilla = brand.equalsIgnoreCase("vanilla");
         
         // Check for Geyser spoofing first
@@ -363,12 +365,12 @@ public class AntiSpoofPlugin extends JavaPlugin {
         if (configManager.isBlockedChannelsEnabled() && hasChannels) {
             if (configManager.isChannelWhitelistEnabled()) {
                 // Whitelist mode
-                if (!detectionManager.checkChannelWhitelist(data.getChannels())) {
+                if (!detectionManager.checkChannelWhitelist(filteredChannels)) {
                     return true;
                 }
             } else {
                 // Blacklist mode
-                String blockedChannel = detectionManager.findBlockedChannel(data.getChannels());
+                String blockedChannel = detectionManager.findBlockedChannel(filteredChannels);
                 if (blockedChannel != null) {
                     return true;
                 }
@@ -391,7 +393,7 @@ public class AntiSpoofPlugin extends JavaPlugin {
                     boolean patternMatched = false;
                     
                     // Check each player channel against this pattern
-                    for (String channel : data.getChannels()) {
+                    for (String channel : filteredChannels) {
                         try {
                             if (pattern.matcher(channel).matches()) {
                                 patternMatched = true;

--- a/src/main/java/com/gigazelensky/antispoof/commands/AntiSpoofCommand.java
+++ b/src/main/java/com/gigazelensky/antispoof/commands/AntiSpoofCommand.java
@@ -12,6 +12,7 @@ import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -300,14 +301,15 @@ public class AntiSpoofCommand implements CommandExecutor, TabCompleter {
                 
                 if (!whitelistMode.equals("FALSE")) {
                     // Whitelist mode
-                    boolean passesWhitelist = plugin.getDetectionManager().checkChannelWhitelist(data.getChannels());
+                    Set<String> filtered = plugin.getDetectionManager().getFilteredChannels(data.getChannels());
+                    boolean passesWhitelist = plugin.getDetectionManager().checkChannelWhitelist(filtered);
                     if (!passesWhitelist) {
                         if (whitelistMode.equals("STRICT")) {
                             // Get missing channels for strict mode
                             List<String> missingChannels = new ArrayList<>();
                             for (String whitelistedChannel : plugin.getConfigManager().getBlockedChannels()) {
                                 boolean found = false;
-                                for (String playerChannel : data.getChannels()) {
+                                for (String playerChannel : filtered) {
                                     try {
                                         if (playerChannel.matches(whitelistedChannel)) {
                                             found = true;
@@ -338,7 +340,7 @@ public class AntiSpoofCommand implements CommandExecutor, TabCompleter {
                     }
                 } else {
                     // Blacklist mode - check for blocked channels
-                    String blockedChannel = plugin.getDetectionManager().findBlockedChannel(data.getChannels());
+                    String blockedChannel = plugin.getDetectionManager().findBlockedChannel(filtered);
                     if (blockedChannel != null) {
                         flagReasons.add("Using blocked channel: " + blockedChannel);
                     }

--- a/src/main/java/com/gigazelensky/antispoof/commands/AntiSpoofCommand.java
+++ b/src/main/java/com/gigazelensky/antispoof/commands/AntiSpoofCommand.java
@@ -299,9 +299,10 @@ public class AntiSpoofCommand implements CommandExecutor, TabCompleter {
             if (hasChannels && plugin.getConfigManager().isBlockedChannelsEnabled()) {
                 String whitelistMode = plugin.getConfigManager().getChannelWhitelistMode();
                 
+                Set<String> filtered = plugin.getDetectionManager().getFilteredChannels(data.getChannels());
+
                 if (!whitelistMode.equals("FALSE")) {
                     // Whitelist mode
-                    Set<String> filtered = plugin.getDetectionManager().getFilteredChannels(data.getChannels());
                     boolean passesWhitelist = plugin.getDetectionManager().checkChannelWhitelist(filtered);
                     if (!passesWhitelist) {
                         if (whitelistMode.equals("STRICT")) {


### PR DESCRIPTION
## Summary
- exclude `minecraft:brand` from spoof detection
- expose filtered channel helper
- apply filtered channels across plugin and commands

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e84e57ec833382a72a5625e80fd6