### PR TITLE
Add MiniMessage color support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.gigazelensky</groupId>
     <artifactId>antispoof</artifactId>
-    <version>1.2.4</version>
+    <version>1.2.6</version>
     <packaging>jar</packaging>
 
     <name>AntiSpoof</name>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.14.0</version>
+            <version>4.21.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
             <version>2.2.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.14.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.gigazelensky</groupId>
     <artifactId>antispoof</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.4</version>
     <packaging>jar</packaging>
 
     <name>AntiSpoof</name>

--- a/src/main/java/com/gigazelensky/antispoof/AntiSpoofPlugin.java
+++ b/src/main/java/com/gigazelensky/antispoof/AntiSpoofPlugin.java
@@ -32,7 +32,6 @@ public class AntiSpoofPlugin extends JavaPlugin {
     private AlertManager alertManager;
     private DetectionManager detectionManager;
     private PlayerEventListener playerEventListener;
-    private VersionChecker versionChecker;
     
     private final ConcurrentHashMap<UUID, PlayerData> playerDataMap = new ConcurrentHashMap<>();
     private final Map<UUID, String> playerBrands = new ConcurrentHashMap<>();
@@ -51,7 +50,7 @@ public class AntiSpoofPlugin extends JavaPlugin {
         this.discordWebhookHandler = new DiscordWebhookHandler(this);
         
         // Initialize version checker
-        this.versionChecker = new VersionChecker(this);
+        new VersionChecker(this);
         
         // Initialize PacketEvents
         PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
@@ -393,7 +392,6 @@ public class AntiSpoofPlugin extends JavaPlugin {
                 // For each required channel pattern, check if any player channel matches it
                 for (int i = 0; i < brandConfig.getRequiredChannels().size(); i++) {
                     Pattern pattern = brandConfig.getRequiredChannels().get(i);
-                    String patternStr = brandConfig.getRequiredChannelStrings().get(i);
                     boolean patternMatched = false;
                     
                     // Check each player channel against this pattern

--- a/src/main/java/com/gigazelensky/antispoof/managers/AlertManager.java
+++ b/src/main/java/com/gigazelensky/antispoof/managers/AlertManager.java
@@ -4,7 +4,6 @@ import com.gigazelensky.antispoof.AntiSpoofPlugin;
 import com.gigazelensky.antispoof.data.PlayerData;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import net.kyori.adventure.text.Component;
 import com.gigazelensky.antispoof.utils.MessageUtil;
 
 import java.util.*;
@@ -68,12 +67,12 @@ public class AlertManager {
      * @param message The message to send
      */
     public void sendAlertToRecipients(String message) {
-        Component component = MessageUtil.miniMessage(message);
+        String formatted = MessageUtil.miniMessage(message);
 
         for (UUID uuid : playersWithAlertPermission) {
             Player player = plugin.getServer().getPlayer(uuid);
             if (player != null && player.isOnline()) {
-                player.sendMessage(component);
+                player.sendMessage(formatted);
             }
         }
     }

--- a/src/main/java/com/gigazelensky/antispoof/managers/AlertManager.java
+++ b/src/main/java/com/gigazelensky/antispoof/managers/AlertManager.java
@@ -3,8 +3,9 @@ package com.gigazelensky.antispoof.managers;
 import com.gigazelensky.antispoof.AntiSpoofPlugin;
 import com.gigazelensky.antispoof.data.PlayerData;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
+import net.kyori.adventure.text.Component;
+import com.gigazelensky.antispoof.utils.MessageUtil;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -67,12 +68,12 @@ public class AlertManager {
      * @param message The message to send
      */
     public void sendAlertToRecipients(String message) {
-        String coloredMessage = ChatColor.translateAlternateColorCodes('&', message);
-        
+        Component component = MessageUtil.miniMessage(message);
+
         for (UUID uuid : playersWithAlertPermission) {
             Player player = plugin.getServer().getPlayer(uuid);
             if (player != null && player.isOnline()) {
-                player.sendMessage(coloredMessage);
+                player.sendMessage(component);
             }
         }
     }

--- a/src/main/java/com/gigazelensky/antispoof/managers/DetectionManager.java
+++ b/src/main/java/com/gigazelensky/antispoof/managers/DetectionManager.java
@@ -3,7 +3,6 @@ package com.gigazelensky.antispoof.managers;
 import com.gigazelensky.antispoof.AntiSpoofPlugin;
 import com.gigazelensky.antispoof.data.PlayerData;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 import java.util.*;
@@ -513,15 +512,6 @@ public class DetectionManager {
                 processViolations(player, finalViolations, finalBrand);
             });
         }
-    }
-    
-    /**
-     * Alias for checking player with checkRequiredChannels parameter
-     * @param player The player to check
-     * @param isJoinCheck Whether this is an initial join check
-     */
-    private void checkPlayer(Player player, boolean isJoinCheck) {
-        checkPlayer(player, isJoinCheck, true);
     }
     
     /**

--- a/src/main/java/com/gigazelensky/antispoof/utils/DiscordWebhookHandler.java
+++ b/src/main/java/com/gigazelensky/antispoof/utils/DiscordWebhookHandler.java
@@ -4,7 +4,6 @@ import com.gigazelensky.antispoof.AntiSpoofPlugin;
 import com.gigazelensky.antispoof.data.PlayerData;
 import com.gigazelensky.antispoof.managers.ConfigManager;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 import java.awt.Color;
@@ -507,7 +506,7 @@ public class DiscordWebhookHandler {
                                           (isCompactUpdate ? " (modified channel)" : ""));
                 }
                 
-                URL url = new URL(webhookUrl);
+                URL url = java.net.URI.create(webhookUrl).toURL();
                 HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                 connection.setRequestMethod("POST");
                 connection.setRequestProperty("Content-Type", "application/json");

--- a/src/main/java/com/gigazelensky/antispoof/utils/MessageUtil.java
+++ b/src/main/java/com/gigazelensky/antispoof/utils/MessageUtil.java
@@ -2,6 +2,7 @@ package com.gigazelensky.antispoof.utils;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.ChatColor;
 
 import java.util.regex.Matcher;
@@ -18,16 +19,17 @@ public final class MessageUtil {
             Pattern.compile("([&§]#[A-Fa-f0-9]{6})|([&§]x([&§][A-Fa-f0-9]){6})");
 
     /**
-     * Parses a string containing legacy color codes or MiniMessage markup into a
-     * {@link Component}. Hex color codes using the &#RRGGBB or &x&F&F&F&F&F&F
-     * formats are also supported.
+     * Parses a string containing legacy color codes or MiniMessage markup and
+     * returns a legacy formatted string compatible with older Bukkit
+     * versions. Hex color codes using the &#RRGGBB or &x&F&F&F&F&F&F formats
+     * are also supported.
      *
      * @param input the input string
-     * @return the parsed component
+     * @return the parsed string with legacy colour codes
      */
-    public static Component miniMessage(String input) {
+    public static String miniMessage(String input) {
         if (input == null || input.isEmpty()) {
-            return Component.empty();
+            return "";
         }
 
         // Unescape common sequences when received via commands
@@ -70,6 +72,7 @@ public final class MessageUtil {
                 .replace("§n", "<underlined>")
                 .replace("§o", "<italic>");
 
-        return MiniMessage.miniMessage().deserialize(input).compact();
+        Component component = MiniMessage.miniMessage().deserialize(input).compact();
+        return LegacyComponentSerializer.legacySection().serialize(component);
     }
 }

--- a/src/main/java/com/gigazelensky/antispoof/utils/MessageUtil.java
+++ b/src/main/java/com/gigazelensky/antispoof/utils/MessageUtil.java
@@ -1,0 +1,75 @@
+package com.gigazelensky.antispoof.utils;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.ChatColor;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class for parsing color codes and MiniMessage strings.
+ */
+public final class MessageUtil {
+    private MessageUtil() {}
+
+    // Matches hex colors in both '&#RRGGBB' and '&x&F&F&F&F&F&F' formats
+    private static final Pattern HEX_PATTERN =
+            Pattern.compile("([&§]#[A-Fa-f0-9]{6})|([&§]x([&§][A-Fa-f0-9]){6})");
+
+    /**
+     * Parses a string containing legacy color codes or MiniMessage markup into a
+     * {@link Component}. Hex color codes using the &#RRGGBB or &x&F&F&F&F&F&F
+     * formats are also supported.
+     *
+     * @param input the input string
+     * @return the parsed component
+     */
+    public static Component miniMessage(String input) {
+        if (input == null || input.isEmpty()) {
+            return Component.empty();
+        }
+
+        // Unescape common sequences when received via commands
+        input = input.replace("\\n", "\n").replace("\\\"", "\"");
+
+        // Convert hex color codes to MiniMessage format
+        Matcher matcher = HEX_PATTERN.matcher(input);
+        StringBuilder sb = new StringBuilder(input.length());
+        while (matcher.find()) {
+            String hex = matcher.group(0).replaceAll("[&§x#]", "");
+            matcher.appendReplacement(sb, "<#" + hex + ">");
+        }
+        input = matcher.appendTail(sb).toString();
+
+        // Translate standard legacy color codes to section symbol
+        input = ChatColor.translateAlternateColorCodes('&', input);
+
+        // Map legacy codes to MiniMessage tags that are not parsed automatically
+        input = input
+                .replace("§0", "<!b><!i><!u><!st><!obf><black>")
+                .replace("§1", "<!b><!i><!u><!st><!obf><dark_blue>")
+                .replace("§2", "<!b><!i><!u><!st><!obf><dark_green>")
+                .replace("§3", "<!b><!i><!u><!st><!obf><dark_aqua>")
+                .replace("§4", "<!b><!i><!u><!st><!obf><dark_red>")
+                .replace("§5", "<!b><!i><!u><!st><!obf><dark_purple>")
+                .replace("§6", "<!b><!i><!u><!st><!obf><gold>")
+                .replace("§7", "<!b><!i><!u><!st><!obf><gray>")
+                .replace("§8", "<!b><!i><!u><!st><!obf><dark_gray>")
+                .replace("§9", "<!b><!i><!u><!st><!obf><blue>")
+                .replace("§a", "<!b><!i><!u><!st><!obf><green>")
+                .replace("§b", "<!b><!i><!u><!st><!obf><aqua>")
+                .replace("§c", "<!b><!i><!u><!st><!obf><red>")
+                .replace("§d", "<!b><!i><!u><!st><!obf><light_purple>")
+                .replace("§e", "<!b><!i><!u><!st><!obf><yellow>")
+                .replace("§f", "<!b><!i><!u><!st><!obf><white>")
+                .replace("§r", "<reset>")
+                .replace("§k", "<obfuscated>")
+                .replace("§l", "<bold>")
+                .replace("§m", "<strikethrough>")
+                .replace("§n", "<underlined>")
+                .replace("§o", "<italic>");
+
+        return MiniMessage.miniMessage().deserialize(input).compact();
+    }
+}

--- a/src/main/java/com/gigazelensky/antispoof/utils/VersionChecker.java
+++ b/src/main/java/com/gigazelensky/antispoof/utils/VersionChecker.java
@@ -86,7 +86,7 @@ public class VersionChecker implements Listener {
      * Fetches the latest release version from GitHub API
      */
     private String getLatestRelease() throws IOException {
-        URL url = new URL(GITHUB_API_URL);
+        URL url = java.net.URI.create(GITHUB_API_URL).toURL();
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setRequestMethod("GET");
         connection.setRequestProperty("Accept", "application/vnd.github.v3+json");

--- a/src/main/java/com/gigazelensky/antispoof/utils/VersionChecker.java
+++ b/src/main/java/com/gigazelensky/antispoof/utils/VersionChecker.java
@@ -168,11 +168,11 @@ public class VersionChecker implements Listener {
      * Sends update notification to a specific player
      */
     private void sendUpdateNotification(Player player) {
-        String msg = "&7=======================================\n" +
+        String msg = "&7=========================================\n" +
                 "&bA new version of &lAntiSpoof&b is available: &av" + latestVersion + "\n" +
                 "&bYou are currently running &ev" + plugin.getDescription().getVersion() + "\n" +
                 "&bDownload from: &agithub.com/GigaZelensky/AntiSpoof/releases/latest\n" +
-                "&7=======================================";
+                "&7=========================================";
         player.sendMessage(MessageUtil.miniMessage(msg));
     }
 

--- a/src/main/java/com/gigazelensky/antispoof/utils/VersionChecker.java
+++ b/src/main/java/com/gigazelensky/antispoof/utils/VersionChecker.java
@@ -2,7 +2,7 @@ package com.gigazelensky.antispoof.utils;
 
 import com.gigazelensky.antispoof.AntiSpoofPlugin;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
+import com.gigazelensky.antispoof.utils.MessageUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -168,14 +168,12 @@ public class VersionChecker implements Listener {
      * Sends update notification to a specific player
      */
     private void sendUpdateNotification(Player player) {
-        player.sendMessage(ChatColor.GRAY + "=======================================================");
-        player.sendMessage(ChatColor.AQUA + "A new version of " + ChatColor.BOLD + "AntiSpoof" + 
-                          ChatColor.AQUA + " is available: " + ChatColor.GREEN + "v" + latestVersion);
-        player.sendMessage(ChatColor.AQUA + "You are currently running " + 
-                          ChatColor.YELLOW + "v" + plugin.getDescription().getVersion());
-        player.sendMessage(ChatColor.AQUA + "Download from: " + ChatColor.GREEN + 
-                          "github.com/GigaZelensky/AntiSpoof/releases/latest");
-        player.sendMessage(ChatColor.GRAY + "=======================================================");
+        String msg = "&7============================================\n" +
+                "&bA new version of &lAntiSpoof&b is available: &av" + latestVersion + "\n" +
+                "&bYou are currently running &ev" + plugin.getDescription().getVersion() + "\n" +
+                "&bDownload from: &agithub.com/GigaZelensky/AntiSpoof/releases/latest\n" +
+                "&7============================================";
+        player.sendMessage(MessageUtil.miniMessage(msg));
     }
 
     /**

--- a/src/main/java/com/gigazelensky/antispoof/utils/VersionChecker.java
+++ b/src/main/java/com/gigazelensky/antispoof/utils/VersionChecker.java
@@ -168,11 +168,11 @@ public class VersionChecker implements Listener {
      * Sends update notification to a specific player
      */
     private void sendUpdateNotification(Player player) {
-        String msg = "&7============================================\n" +
+        String msg = "&7=======================================\n" +
                 "&bA new version of &lAntiSpoof&b is available: &av" + latestVersion + "\n" +
                 "&bYou are currently running &ev" + plugin.getDescription().getVersion() + "\n" +
                 "&bDownload from: &agithub.com/GigaZelensky/AntiSpoof/releases/latest\n" +
-                "&7============================================";
+                "&7=======================================";
         player.sendMessage(MessageUtil.miniMessage(msg));
     }
 


### PR DESCRIPTION
## Summary
- add `adventure-text-minimessage` dependency
- implement `MessageUtil` to parse legacy, hex and MiniMessage codes
- use `MessageUtil` for alert messages
- show update notifications with MiniMessage

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684499aa61fc8333b32121342c991264