### PR TITLE
Extend version range to Minecraft 1.8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   **Advanced, customizable Minecraft plugin for detecting client spoofing through brand analysis and channel monitoring**
   
   ![Java](https://img.shields.io/badge/Java-21%2B-orange)
-  ![Minecraft](https://img.shields.io/badge/Minecraft-1.20.4%2B-brightgreen)
+  ![Minecraft](https://img.shields.io/badge/Minecraft-1.8.9-1.21.5-brightgreen)
   ![License](https://img.shields.io/badge/License-GPL%20v3-blue)
 </div>
 
@@ -204,7 +204,7 @@ This transparency helps administrators understand exactly how the plugin is work
 
 ### Requirements
 - Java 21 or higher
-- Spigot, Paper, or compatible fork (1.20.4+)
+- Spigot, Paper, or compatible fork (1.8.9-1.21.5)
 - Appropriate server permissions to install plugins
 
 ### Optional Dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <packetevents.version>2.8.1-SNAPSHOT</packetevents.version>
-        <spigot.version>1.20.4-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.8.8-R0.1-SNAPSHOT</spigot.version>
         <placeholderapi.version>2.11.6</placeholderapi.version>
     </properties>
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,6 @@
 name: AntiSpoof
 version: ${project.version}
 main: com.gigazelensky.antispoof.AntiSpoofPlugin
-api-version: 1.20
 softdepend: [ProtocolLib, ProtocolSupport, ViaVersion, ViaBackwards, ViaRewind, Geyser-Spigot, PlaceholderAPI, GrimAC, floodgate]
 # Add PacketEvents as an optional dependency for the lite version
 loadbefore: [PacketEvents]


### PR DESCRIPTION
## Summary
- expand supported version range
- remove api-version requirement so the plugin loads on 1.8 servers
- compile against 1.8.8 Spigot API

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b91c1b588333a91ba0b1e50b557c