### PR TITLE
Add translatable alert options and mod probe commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,9 @@ translatable-keys:
     only-on-move: false
     # When enabled, probes wait until the player moves and are sent only while
     # they keep moving. This helps hide the sign GUI during the check.
+    alert-once-per-label: true
+    # When enabled, each mod label will only alert once per player even if the
+    # probes run again later in the same session.
 
 # ──────────────────────────────────────────────────────────
 #                Bedrock Handling Settings

--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ AntiSpoof integrates with PlaceholderAPI to provide useful placeholders for othe
 | `%antispoof_brand%` | Shows the player's client brand | "vanilla", "fabric", "lunarclient:v1.8.9-10b0" |
 | `%antispoof_channels%` | Shows a comma-separated list of player's registered channels | "minecraft:brand, fabric:registry/sync, fabric:screen-handler-api" |
 | `%antispoof_channels_count%` | Shows the number of registered channels | "5" |
+| `%antispoof_mods%` | Shows a comma-separated list of detected mod labels | "Sodium, ModMenu" |
+| `%antispoof_mods_count%` | Shows the number of detected mod labels | "2" |
 | `%antispoof_is_spoofing%` | Returns whether the player is detected as spoofing | "true" or "false" |
 | `%antispoof_is_bedrock%` | Returns whether the player is detected as a Bedrock player | "true" or "false" |
 
@@ -281,7 +283,7 @@ Here are some examples of how you can use these placeholders:
 
 #### Welcome Message (with an essentials-like plugin)
 ```
-&aWelcome! &7You're using &e%antispoof_brand%&7 with &e%antispoof_channels_count%&7 plugin channels.
+&aWelcome! &7You're using &e%antispoof_brand%&7 with &e%antispoof_channels_count%&7 channels and &e%antispoof_mods_count%&7 mods detected.
 ```
 
 #### Custom Scoreboard
@@ -289,6 +291,7 @@ Here are some examples of how you can use these placeholders:
 &6═════ &bServer Info &6═════
 &7Client: &e%antispoof_brand%
 &7Channels: &e%antispoof_channels_count%
+&7Mods: &e%antispoof_mods_count%
 &7Bedrock: &e%antispoof_is_bedrock%
 &6════════════════════
 ```
@@ -546,7 +549,7 @@ vanillaspoof-check:
   # Whether to punish the player if detection is positive
   punish: false
   # Punishment actions to execute
-  # Available placeholders: %player%, %reason%, %brand%, %channel%
+  # Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
   punishments:
     - "kick %player% &cVanilla spoof detected: %reason%"
     # - "ban %player% &cVanilla client spoofing detected"
@@ -567,7 +570,7 @@ non-vanilla-check:
   # Whether to punish the player if detection is positive
   punish: false
   # Punishment actions to execute
-  # Available placeholders: %player%, %reason%, %brand%, %channel%
+  # Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
   punishments:
     - "kick %player% &cNon-vanilla client with channels detected"
     # - "tempban %player% 1h &cUsing a modified client"
@@ -631,7 +634,7 @@ blocked-channels:
   # Whether to punish the player if detection is positive
   punish: false
   # Punishment actions to execute
-  # Available placeholders: %player%, %reason%, %brand%, %channel%
+  # Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
   punishments:
     - "kick %player% &cBlocked channel detected: %channel%"
     # - "tempban %player% 1d &cUsing blocked mod channels"
@@ -882,7 +885,7 @@ bedrock-handling:
     # Whether to punish the player if detection is positive
     punish: false
     # Punishment actions to execute
-    # Available placeholders: %player%, %reason%, %brand%
+    # Available placeholders: %player%, %reason%, %brand%, %mods%, %mods_count%
     punishments:
       - "kick %player% &cGeyser client spoofing detected"
       # - "ban %player% &cGeyser client spoofing"
@@ -938,7 +941,7 @@ update-checker:
 # Legacy global punishment system (for backward compatibility)
 # These punishments will be used if a specific check has 'punish: true'
 # but doesn't have its own punishments defined
-# Available placeholders: %player%, %reason%, %brand%, %channel%
+# Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
 punishments:
   - "kick %player% &cSuspicious client detected!"
   # - "ban %player% &cClient spoofing detected"
@@ -949,7 +952,7 @@ punishments:
 # Legacy global alert system (for backward compatibility)
 # These messages will be used if a specific check is enabled
 # but doesn't have its own alerts defined
-# Available placeholders: %player%, %reason%, %brand%, %channel%
+# Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
 # Defines the message sent to players with the `antispoof.alerts` permission
 # when a spoofing attempt is detected.
 messages:

--- a/src/main/java/com/gigazelensky/antispoof/AntiSpoofPlugin.java
+++ b/src/main/java/com/gigazelensky/antispoof/AntiSpoofPlugin.java
@@ -476,7 +476,10 @@ public class AntiSpoofPlugin extends JavaPlugin {
         // Clean up all tracked data for this player
         getDetectionManager().handlePlayerQuit(uuid);
         if (translatableKeyManager != null) {
-            // cleanup placeholder
+            Player p = Bukkit.getPlayer(uuid);
+            if (p != null) {
+                translatableKeyManager.stopMods(p);
+            }
         }
         getAlertManager().handlePlayerQuit(uuid);
         getDiscordWebhookHandler().handlePlayerQuit(uuid);

--- a/src/main/java/com/gigazelensky/antispoof/hooks/AntiSpoofPlaceholders.java
+++ b/src/main/java/com/gigazelensky/antispoof/hooks/AntiSpoofPlaceholders.java
@@ -75,6 +75,33 @@ public class AntiSpoofPlaceholders extends PlaceholderExpansion {
             return String.valueOf(data.getChannels().size());
         }
 
+        // %antispoof_mods%
+        if (identifier.equals("mods")) {
+            UUID uuid = player.getUniqueId();
+            PlayerData data = plugin.getPlayerDataMap().get(uuid);
+            if (data == null) {
+                return "none";
+            }
+
+            Set<String> mods = data.getDetectedMods();
+            if (mods.isEmpty()) {
+                return "none";
+            }
+
+            return String.join(", ", mods);
+        }
+
+        // %antispoof_mods_count%
+        if (identifier.equals("mods_count")) {
+            UUID uuid = player.getUniqueId();
+            PlayerData data = plugin.getPlayerDataMap().get(uuid);
+            if (data == null) {
+                return "0";
+            }
+
+            return String.valueOf(data.getDetectedMods().size());
+        }
+
         // %antispoof_is_spoofing%
         if (identifier.equals("is_spoofing")) {
             return plugin.isPlayerSpoofing(player) ? "true" : "false";

--- a/src/main/java/com/gigazelensky/antispoof/managers/ConfigManager.java
+++ b/src/main/java/com/gigazelensky/antispoof/managers/ConfigManager.java
@@ -668,6 +668,7 @@ public class ConfigManager {
 
     // Translatable key detection
     private boolean translatableKeysEnabled;
+    private boolean translatableAlertOnce;
     private final Map<String, TranslatableModConfig> translatableMods = new HashMap<>();
     private TranslatableModConfig defaultTranslatableConfig;
 
@@ -698,6 +699,8 @@ public class ConfigManager {
         }
 
         translatableKeysEnabled = main.getBoolean("enabled", false);
+        translatableAlertOnce = main.getConfigurationSection("check")
+                .getBoolean("alert-once-per-label", false);
 
         ConfigurationSection def = main.getConfigurationSection("default");
         defaultTranslatableConfig = new TranslatableModConfig();
@@ -831,6 +834,10 @@ public class ConfigManager {
 
     public boolean isTranslatableOnlyOnMove() {
         return config.getBoolean("translatable-keys.check.only-on-move", false);
+    }
+
+    public boolean isTranslatableAlertOnce() {
+        return translatableAlertOnce;
     }
     
     /**

--- a/src/main/java/com/gigazelensky/antispoof/managers/ConfigManager.java
+++ b/src/main/java/com/gigazelensky/antispoof/managers/ConfigManager.java
@@ -700,7 +700,7 @@ public class ConfigManager {
 
         translatableKeysEnabled = main.getBoolean("enabled", false);
         translatableAlertOnce = main.getConfigurationSection("check")
-                .getBoolean("alert-once-per-label", false);
+                .getBoolean("alert-once-per-label", true);
 
         ConfigurationSection def = main.getConfigurationSection("default");
         defaultTranslatableConfig = new TranslatableModConfig();

--- a/src/main/java/com/gigazelensky/antispoof/managers/DetectionManager.java
+++ b/src/main/java/com/gigazelensky/antispoof/managers/DetectionManager.java
@@ -882,8 +882,14 @@ public class DetectionManager {
         ConfigManager.TranslatableModConfig modConfig = config.getTranslatableModConfig(key);
         String label = modConfig.getLabel() != null && !modConfig.getLabel().isEmpty() ? modConfig.getLabel() : key;
 
+        PlayerData pdata = plugin.getPlayerDataMap().get(player.getUniqueId());
+        boolean alreadyFlagged = pdata != null && pdata.getDetectedMods().contains(label);
+
+        if (config.isTranslatableAlertOnce() && alreadyFlagged) {
+            return;
+        }
+
         if (type == TranslatableEventType.TRANSLATED) {
-            PlayerData pdata = plugin.getPlayerDataMap().get(player.getUniqueId());
             if (pdata != null) pdata.addDetectedMod(label);
             if (modConfig.shouldAlert()) {
                 plugin.getAlertManager().sendTranslatableViolationAlert(player, label, "TRANSLATED_KEY", modConfig);
@@ -894,6 +900,7 @@ public class DetectionManager {
                 if (data != null) data.setAlreadyPunished(true);
             }
         } else if (type == TranslatableEventType.REQUIRED_MISS) {
+            if (pdata != null) pdata.addDetectedMod(label);
             if (modConfig.shouldAlert()) {
                 plugin.getAlertManager().sendTranslatableViolationAlert(player, label, "REQUIRED_KEY_MISS", modConfig);
             }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -352,9 +352,9 @@ translatable-keys:
     only-on-move: false
     # When true, delay the probes until the player moves and continue only
     # while they keep moving.
-  # When enabled, each mod label will only alert once per player even if
-  # the probes are triggered again during the same session.
-  alert-once-per-label: false
+    alert-once-per-label: true
+    # When enabled, each mod label will only alert once per player even if
+    # the probes are triggered again during the same session.
 
 # ──────────────────────────────────────────────────────────
 #                Bedrock Handling Settings

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -45,7 +45,7 @@ vanillaspoof-check:
   # Whether to punish the player if detection is positive
   punish: false
   # Punishment actions to execute
-  # Available placeholders: %player%, %reason%, %brand%, %channel%
+  # Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
   punishments:
     - "kick %player% &cVanilla spoof detected: %reason%"
     # - "ban %player% &cVanilla client spoofing detected"
@@ -66,7 +66,7 @@ non-vanilla-check:
   # Whether to punish the player if detection is positive
   punish: false
   # Punishment actions to execute
-  # Available placeholders: %player%, %reason%, %brand%, %channel%
+  # Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
   punishments:
     - "kick %player% &cNon-vanilla client with channels detected"
     # - "tempban %player% 1h &cUsing a modified client"
@@ -130,7 +130,7 @@ blocked-channels:
   # Whether to punish the player if detection is positive
   punish: false
   # Punishment actions to execute
-  # Available placeholders: %player%, %reason%, %brand%, %channel%
+  # Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
   punishments:
     - "kick %player% &cBlocked channel detected: %channel%"
     # - "tempban %player% 1d &cUsing blocked mod channels"
@@ -352,6 +352,9 @@ translatable-keys:
     only-on-move: false
     # When true, delay the probes until the player moves and continue only
     # while they keep moving.
+  # When enabled, each mod label will only alert once per player even if
+  # the probes are triggered again during the same session.
+  alert-once-per-label: false
 
 # ──────────────────────────────────────────────────────────
 #                Bedrock Handling Settings
@@ -381,7 +384,7 @@ bedrock-handling:
     # Whether to punish the player if detection is positive
     punish: false
     # Punishment actions to execute
-    # Available placeholders: %player%, %reason%, %brand%
+    # Available placeholders: %player%, %reason%, %brand%, %mods%, %mods_count%
     punishments:
       - "kick %player% &cGeyser client spoofing detected"
       # - "ban %player% &cGeyser client spoofing"
@@ -437,7 +440,7 @@ update-checker:
 # Legacy global punishment system (for backward compatibility)
 # These punishments will be used if a specific check has 'punish: true'
 # but doesn't have its own punishments defined
-# Available placeholders: %player%, %reason%, %brand%, %channel%
+# Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
 punishments:
   - "kick %player% &cSuspicious client detected!"
   # - "ban %player% &cClient spoofing detected"
@@ -448,7 +451,7 @@ punishments:
 # Legacy global alert system (for backward compatibility)
 # These messages will be used if a specific check is enabled
 # but doesn't have its own alerts defined
-# Available placeholders: %player%, %reason%, %brand%, %channel%
+# Available placeholders: %player%, %reason%, %brand%, %channel%, %mods%, %mods_count%
 # Defines the message sent to players with the `antispoof.alerts` permission
 # when a spoofing attempt is detected.
 messages:


### PR DESCRIPTION
## Summary
- add `alert-once-per-label` for translatable key checks
- allow head movement to trigger probes
- add `/antispoof runmods` and `/antispoof stopmods` commands
- stop probes on player quit
- avoid duplicate mod alerts when `alert-once-per-label` is enabled
- add `%antispoof_mods%` and `%antispoof_mods_count%` placeholders

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848aa00bef483339a752fd25be457de