### PR TITLE
Fix required key check in probe

### DIFF
--- a/src/main/java/com/gigazelensky/antispoof/managers/TranslatableKeyManager.java
+++ b/src/main/java/com/gigazelensky/antispoof/managers/TranslatableKeyManager.java
@@ -346,6 +346,8 @@ public final class TranslatableKeyManager extends PacketListenerAbstract impleme
         if (translated) {
             if(cfg.isDebugMode()) plugin.getLogger().info("[Debug] " + p.getName() + " translated: '" + key + "' -> '" + response + "' (" + label + ")");
             probe.translated.add(key);
+            probe.failedForNext.remove(key); // clear any earlier failure
+            probe.timedOut.remove(key);
             if (!isRequired) {
                 detect.handleTranslatable(p, TranslatableEventType.TRANSLATED, key);
             }
@@ -357,8 +359,10 @@ public final class TranslatableKeyManager extends PacketListenerAbstract impleme
 
     private void finishRound(Player p, Probe probe) {
         for (String req : cfg.getTranslatableRequiredKeys()) {
-            if (!probe.translated.contains(req))
+            // Only flag keys that ultimately failed translation
+            if (probe.failedForNext.containsKey(req)) {
                 detect.handleTranslatable(p, TranslatableEventType.REQUIRED_MISS, req);
+            }
         }
         boolean anyTimeout = !probe.timedOut.isEmpty();
         boolean allTimeout = anyTimeout && probe.timedOut.containsAll(probe.allKeys);


### PR DESCRIPTION
## Summary
- only mark required keys that fail translation
- clean up failure sets when a key successfully translates

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e464bcf0c8333b76931ec2f55d0f6